### PR TITLE
Return 503 status code.

### DIFF
--- a/downtime/middleware.py
+++ b/downtime/middleware.py
@@ -19,5 +19,5 @@ class DowntimeMiddleware(object):
             if url_redirect:
                 return redirect(url_redirect)
             else:
-                return render(request, "downtime/downtime.html")
+                return render(request, "downtime/downtime.html", status=503)
 


### PR DESCRIPTION
Return a status code of 503 when downtime is enabled. See
http://googlewebmastercentral.blogspot.com/2011/01/how-to-deal-with-planned-site-downtime.html
for why this is the best status code to return when dealing with planned
maintenance.