### PR TITLE
Show downtime start and end times in the title

### DIFF
--- a/downtime/models.py
+++ b/downtime/models.py
@@ -14,4 +14,4 @@ class Period(models.Model):
     objects = PeriodManager()
 
     def __str__(self):
-        return "Scheduled downtime"
+        return "Scheduled Downtime: %s to %s" % (self.start_time, self.end_time)


### PR DESCRIPTION
As is, the downtime titles on the Django Admin are not very useful, especially if there are multiple downtime instances. This change would add the start and end times to that label to better differentiate them.