### PR TITLE
Added url exemption option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Django supports versions 1.4 to 1.8 on Python 2.7 and 3.4.
 
 To install django-downtime::
 
-	pip install django-downtime
+  pip install django-downtime
 
 add to installed apps::
 
-	downtime
+  downtime
 
 Add downtime middleware to ``the top`` your list of installed middlewares::
 
@@ -27,6 +27,13 @@ Add downtime middleware to ``the top`` your list of installed middlewares::
 
 Settings
 --------
+
+Exempted URLs::
+
+    DOWNTIME_EXEMPT_EXACT_URLS = (
+        '/', # exempts homepage
+        '/other_location/not_down/page',
+    )
 
 Exempted Paths::
 
@@ -43,7 +50,7 @@ Templates
 ---------
 
 If no URL Redirect is specified a ``lame`` default template is rendered, this can be overridden
-by specificing a ``downtime/downtime.html`` template.
+by specifying a ``downtime/downtime.html`` template.
 
 Management Commands
 -------------------
@@ -53,10 +60,10 @@ up `python manage.py downtime_end`.
 
 What happens internally when calling `python manage.py downtime_start`?
 
-This sets a start date time and mark is as enabled. We call this "deployment mode", ususally called before
+This sets a start date time and mark is as enabled. We call this "deployment mode", usually called before
 running a deployment script.
 
 What happens internally when calling `python manage.py downtime_end`?
 
 This sets a end date time to all records that has a start date time and no end date time set and are
-marked as enabled. We call this "closing deployment mode", ususally called after running a deployment script.
+marked as enabled. We call this "closing deployment mode", usually called after running a deployment script.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Django supports versions 1.4 to 1.8 on Python 2.7 and 3.4.
 
 To install django-downtime::
 
-  pip install django-downtime
+    pip install django-downtime
 
 add to installed apps::
 
-  downtime
+    downtime
 
 Add downtime middleware to ``the top`` your list of installed middlewares::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,12 +7,12 @@ Django Downtime supports Django 1.4 - 1.8 and Python 2.7 and 3.4.
 
 To install django-downtime::
 
-  pip install django-downtime
+    pip install django-downtime
 
 add to installed apps::
 
     INSTALLED_APPS += (
-  'downtime',
+        'downtime',
     )
 
 Add downtime middleware to ``the top`` your list of installed middlewares::

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,12 +7,12 @@ Django Downtime supports Django 1.4 - 1.8 and Python 2.7 and 3.4.
 
 To install django-downtime::
 
-	pip install django-downtime
+  pip install django-downtime
 
 add to installed apps::
 
     INSTALLED_APPS += (
-	'downtime',
+  'downtime',
     )
 
 Add downtime middleware to ``the top`` your list of installed middlewares::
@@ -22,6 +22,13 @@ Add downtime middleware to ``the top`` your list of installed middlewares::
 
 Settings
 --------
+
+Exempted URLs::
+
+    DOWNTIME_EXEMPT_EXACT_URLS = (
+        '/', # exempts homepage
+        '/other_location/not_down/page',
+    )
 
 Exempted Paths::
 
@@ -38,4 +45,4 @@ Templates
 ---------
 
 If no URL Redirect is specified a ``lame`` default template is rendered, this can be overridden
-by specificing a ``downtime/downtime.html`` template.
+by specifying a ``downtime/downtime.html`` template.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,8 +14,8 @@ to the tuple of ``DOWNTIME_EXEMPT_PATHS`` so that you can still login and bring 
 Using the management command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use `python manage.py downtime_start` to start an unscheduled downtime. This sets a start date time and mark is as enabled. 
-We call this "deployment mode", ususally called before  running a deployment script.
+Use `python manage.py downtime_start` to start an unscheduled downtime. This sets a start date time and mark is as enabled.
+We call this "deployment mode", usually called before running a deployment script.
 
 Bringing The Site Back Up
 -------------------------
@@ -28,11 +28,7 @@ Either delete the ``Period`` instance or uncheck ``enable`` for the current down
 Using the management command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To set the site back up run `python manage.py downtime_end`. 
+To set the site back up run `python manage.py downtime_end`.
 
-This sets a end date time to all records that has a start date time and no end date time set and are 
-marked as enabled. We call this "closing deployment mode", ususally called after running a deployment script.
-
- 
-
-
+This sets a end date time to all records that has a start date time and no end date time set and are
+marked as enabled. We call this "closing deployment mode", usually called after running a deployment script.

--- a/downtime/middleware.py
+++ b/downtime/middleware.py
@@ -6,6 +6,15 @@ from downtime.models import Period
 
 class DowntimeMiddleware(object):
     def process_request(self, request):
+        exempt_exact_urls = getattr(settings,
+                                    'DOWNTIME_EXEMPT_EXACT_URLS', None)
+        if exempt_exact_urls:
+            for url in exempt_exact_urls:
+                print request.path
+                print url
+                if request.path == url:
+                    return None
+
         exempt_paths = getattr(settings, 'DOWNTIME_EXEMPT_PATHS', ('/admin',))
         for path in exempt_paths:
             if request.path.startswith(path):
@@ -20,4 +29,3 @@ class DowntimeMiddleware(object):
                 return redirect(url_redirect)
             else:
                 return render(request, "downtime/downtime.html", status=503)
-

--- a/downtime/middleware.py
+++ b/downtime/middleware.py
@@ -10,8 +10,6 @@ class DowntimeMiddleware(object):
                                     'DOWNTIME_EXEMPT_EXACT_URLS', None)
         if exempt_exact_urls:
             for url in exempt_exact_urls:
-                print request.path
-                print url
                 if request.path == url:
                     return None
 

--- a/downtime/tests/test_middleware.py
+++ b/downtime/tests/test_middleware.py
@@ -15,6 +15,17 @@ class DowntimeMiddlewareTest(TestCase):
         self.request.session = {}
         self.period = PeriodFactory.create()
 
+    def test_exempt_exact_urls(self):
+        self.request.path = '/test/page/id'
+        self.assertTrue(self.dm.process_request(self.request))
+
+        with self.settings(DOWNTIME_EXEMPT_EXACT_URLS=('/test/page/id', )):
+            self.assertIsNone(self.dm.process_request(self.request))
+
+            self.request.path = '/test/page/id/child'
+            self.assertTrue(self.dm.process_request(self.request),
+                            'Children pages are not exempted to exact urls')
+
     def test_exempt_paths(self):
         self.request.path = '/admin'
         self.assertIsNone(self.dm.process_request(self.request))


### PR DESCRIPTION
Pull request for issue #33 

- DOWNTIME_EXEMPT_EXACT_URLS tuple is used to specify urls to be exempt by downtime middleware
- updated README with new option
- fixed typos for 'specifying' and 'usually' in README and docs