### PR TITLE
Add feature to use custom mixin, possible use without database, optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,51 @@
+## What do this branch?
+
+1. now possible use custom mixin
+simple declare list of you mixins in settings:
+```python
+DOWNTIME_MIXIN = ['utils.utility.downtime_mixin', ]  # custom list of you mixins
+DOWNTIME_NODATABASE_MODE = True  # Dont use DataBase for check maintance mode
+```
+where in you project present app named 'utils.utility' and function `downtime_mixin`
+
+from real project:
+```python
+def downtime_mixin(self_object, request):
+    result = request.user.is_superuser
+    if not result:
+        api_key = request.GET.get('api_key')
+        setting_api_key = getattr(settings, 'DOWNTIME_ADTIONAL_API_KEY', None)
+        result = api_key == setting_api_key
+    return not result
+```
+I use Django Rest Framework, and stay possible to use API for maintenance works, so i just declare in settings.py DOWNTIME_ADTIONAL_API_KEY variable and use this for allow requests. Too i use check request super user. This can be possible only if append `downtime.middleware.DowntimeMiddleware` to end of the list MIDDLEWARE.
+2. Also introduce new variable DOWNTIME_NODATABASE_MODE , in this case no database need, this is very important because do query to database every time - bad idea.
+
+Summary my settings looks like:
+```python
+DOWNTIME = True
+.
+.
+.
+if DOWNTIME:
+    DOWNTIME_EXEMPT_PATHS = (
+        '/admin/',
+        '/ru/accounts/login/',
+        '/en/accounts/login/',
+    )
+    DOWNTIME_MIXIN = ['utils.utility.downtime_mixin', ]  # custom list of you mixins
+    DOWNTIME_NODATABASE_MODE = True  # Dont use DataBase for check maintance mode
+    INSTALLED_APPS = (*INSTALLED_APPS, 'downtime',)
+    MIDDLEWARE += ['downtime.middleware.DowntimeMiddleware', ]
+    # MIDDLEWARE.insert(0, 'downtime.middleware.DowntimeMiddleware', )
+
+    # private params
+    DOWNTIME_ADDITIONAL_API_KEY = 'super-puper-secret-key'
+```
+
+
+--------------------------------- END
+
 ## Django Downtime
 
 > Looking For Authors!  This project is currently looking for a user to take it over.  If that sounds like you, send a note to derek at stegelman dot com or open up an issue in this repository.

--- a/downtime/admin.py
+++ b/downtime/admin.py
@@ -1,5 +1,9 @@
-from django.contrib import admin
+from django.conf import settings
 
-from downtime.models import Period
+# use admin only if not use DOWNTIME_NODATABASE_MODE
+downtime_nodatbase_mode = getattr(settings, 'DOWNTIME_NODATABASE_MODE', False)
+if not downtime_nodatbase_mode:
+    from django.contrib import admin
+    from downtime.models import Period
 
-admin.site.register(Period)
+    admin.site.register(Period)

--- a/downtime/middleware.py
+++ b/downtime/middleware.py
@@ -1,8 +1,6 @@
 from django.shortcuts import render, redirect
 from django.conf import settings
 
-from downtime.models import Period
-
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
@@ -11,8 +9,19 @@ except ImportError:
 
 class DowntimeMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        exempt_exact_urls = getattr(settings,
-                                    'DOWNTIME_EXEMPT_EXACT_URLS', None)
+        downtime_mixin = getattr(settings, 'DOWNTIME_MIXIN', None)
+
+        if downtime_mixin:
+            import importlib
+            for mixin in downtime_mixin:
+                mod_name, func_name = mixin.rsplit('.', 1)
+                mod = importlib.import_module(mod_name)
+                func = getattr(mod, func_name)
+                result = func(self, request)
+                if not result:
+                    return None
+
+        exempt_exact_urls = getattr(settings, 'DOWNTIME_EXEMPT_EXACT_URLS', None)
         if exempt_exact_urls:
             for url in exempt_exact_urls:
                 if request.path == url:
@@ -23,9 +32,12 @@ class DowntimeMiddleware(MiddlewareMixin):
             if request.path.startswith(path):
                 return None
 
-        objects = Period.objects.is_down()
+        downtime_nodatbase_mode = getattr(settings, 'DOWNTIME_NODATABASE_MODE', False)
+        if not downtime_nodatbase_mode:
+            from downtime.models import Period
+            objects = Period.objects.is_down()
 
-        if objects.count():
+        if downtime_nodatbase_mode or objects.count():
             # we are down.
             url_redirect = getattr(settings, 'DOWNTIME_URL_REDIRECT', None)
             if url_redirect:


### PR DESCRIPTION
1. now possible use custom mixin
simple declare list of you mixins in settings:
```python
DOWNTIME_MIXIN = ['utils.utility.downtime_mixin', ]  # custom list of you mixins
DOWNTIME_NODATABASE_MODE = True  # Dont use DataBase for check maintance mode
```
where in you project present app named 'utils.utility' and function `downtime_mixin`
from real project:
```python
def downtime_mixin(self_object, request):
    result = request.user.is_superuser
    if not result:
        api_key = request.GET.get('api_key')
        setting_api_key = getattr(settings, 'DOWNTIME_ADTIONAL_API_KEY', None)
        result = api_key == setting_api_key
    return not result
```
I use Django Rest Framework, and stay possible to use API for maintenance works, so i just declare in settings.py DOWNTIME_ADTIONAL_API_KEY variable and use this for allow requests. Too i use check request super user. This can be possible only if append `downtime.middleware.DowntimeMiddleware` to end of the list MIDDLEWARE.
2. Also introduce new variable DOWNTIME_NODATABASE_MODE , in this case no database need, this is very important because do query to database every time - bad idea.

Summary my settings looks like:
```python
DOWNTIME = True
.
.
.
    if DOWNTIME:
        DOWNTIME_EXEMPT_PATHS = (
            '/admin/',
            '/ru/accounts/login/',
            '/en/accounts/login/',
        )
        DOWNTIME_MIXIN = ['utils.utility.downtime_mixin', ]  # custom list of you mixins
        DOWNTIME_NODATABASE_MODE = True  # Dont use DataBase for check maintance mode
        INSTALLED_APPS = (*INSTALLED_APPS, 'downtime',)
        MIDDLEWARE += ['downtime.middleware.DowntimeMiddleware', ]
        # MIDDLEWARE.insert(0, 'downtime.middleware.DowntimeMiddleware', )

        # private params
        DOWNTIME_ADDITIONAL_API_KEY = 'super-puper-secret-key'
```